### PR TITLE
Build from alpine to include a shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN curl -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && \
 
 FROM alpine:3.15.4
 
-COPY --from=build /mkcert/mkcert-v1.4.4-linux-amd64 ./mkcert
+COPY --from=build /mkcert/mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
 
-CMD ["./mkcert"]
+CMD ["/usr/local/bin/mkcert"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apk --no-cache add curl
 RUN curl -JLO "https://dl.filippo.io/mkcert/v1.4.4?for=linux/amd64" && \
   chmod +x mkcert-v1.4.4-linux-amd64
 
-FROM scratch
+FROM alpine:3.15.4
 
-COPY --from=build /mkcert/mkcert-v1.4.4-linux-amd64  ./mkcert
+COPY --from=build /mkcert/mkcert-v1.4.4-linux-amd64 ./mkcert
 
 CMD ["./mkcert"]


### PR DESCRIPTION
When building "from scratch" the Dockerfile doesn't contain anything but the `mkcert` binary, not even a shell, so it's not possible to run two commands with `/bin/sh -c`. Building from alpine solves that, so that the command mentioned in the README works again.